### PR TITLE
Add flexible constructor with context

### DIFF
--- a/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
+++ b/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
@@ -1,7 +1,8 @@
 package com.creativewidgetworks.goldparser.engine;
 
+import static com.creativewidgetworks.goldparser.util.FileHelper.toInputStream;
+
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -293,7 +294,7 @@ public class Parser {
         if (file == null) {
             throw new IOException(FormatHelper.formatMessage("messages", "error.cgt_missing"));
         }
-        return loadTables(new FileInputStream(file));
+        return loadTables(toInputStream(file));
     }
 
     /**

--- a/src/main/java/com/creativewidgetworks/goldparser/parser/GOLDParser.java
+++ b/src/main/java/com/creativewidgetworks/goldparser/parser/GOLDParser.java
@@ -1,14 +1,17 @@
 package com.creativewidgetworks.goldparser.parser;
 
+import static com.creativewidgetworks.goldparser.util.FileHelper.toInputStream;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -64,18 +67,33 @@ public class GOLDParser extends Parser {
     /*----------------------------------------------------------------------------*/
 
     public GOLDParser() {
-        super();
-        setCurrentScope(new Scope("GLOBAL"));    
+        setCurrentScope(new Scope("GLOBAL"));
     }
-    
+
+    /*----------------------------------------------------------------------------*/
+
+    public GOLDParser(GOLDParserBuildContext context) {
+        this();
+        try {
+            loadTables(context.grammar());
+            loadRuleHandlers(context.ruleClasses());
+            setTrimReductions(context.trimReductions());
+            if (ruleHandlers.size() == 0) {
+                throw new IllegalStateException(FormatHelper.formatMessage("messages", "error.handlers_none"));
+            }
+        } catch (Exception e) {
+            addErrorMessage(FormatHelper.formatMessage("messages", "error.table_unloadable", e.getMessage()));
+        }
+    }
+
     /*----------------------------------------------------------------------------*/
 
     public GOLDParser(File cgtFile, String rulesPackage, boolean trimReductions) {
+        this();
         try {
             loadTables(cgtFile);
             loadRuleHandlers(rulesPackage);
             setTrimReductions(trimReductions);
-            setCurrentScope(new Scope("GLOBAL")); 
             if (ruleHandlers.size() == 0) {
                 throw new IllegalStateException(FormatHelper.formatMessage("messages", "error.handlers_none", rulesPackage));
             }
@@ -87,19 +105,19 @@ public class GOLDParser extends Parser {
     /*----------------------------------------------------------------------------*/
 
     public GOLDParser(InputStream cgtFile, String rulesPackage, boolean trimReductions) {
+        this();
         try {
             loadTables(cgtFile);
             loadRuleHandlers(rulesPackage);
             setTrimReductions(trimReductions);
-            setCurrentScope(new Scope("GLOBAL")); 
             if (ruleHandlers.size() == 0) {
                 throw new IllegalStateException(FormatHelper.formatMessage("messages", "error.handlers_none", rulesPackage));
             }
         } catch (Exception e) {
             addErrorMessage(FormatHelper.formatMessage("messages", "error.table_unloadable", e.getMessage()));
         }
-    }    
-    
+    }
+
     /*----------------------------------------------------------------------------*/
 
     public void clear() {
@@ -473,23 +491,42 @@ public class GOLDParser extends Parser {
     /*----------------------------------------------------------------------------*/
 
     public void loadRuleHandlers(String packageName) {
-        try {
-            ruleHandlers.clear();
+        loadRuleHandlers(listClassesInPackage(packageName));
+    }
 
-            List<Class> list = ResourceHelper.findClassesInPackage(packageName);
-            for (Class clazz : list) {
-                Annotation[] annotations = clazz.getAnnotations();
-                for (Annotation annotation : annotations){
-                    if (annotation instanceof ProcessRule){
-                        ProcessRule a = (ProcessRule)annotation;
-                        for (String rule : a.rule()) {
-                            ruleHandlers.put(rule, clazz);
-                        }
-                    }
-                }                
-            }
+    public void loadRuleHandlers(List<Class> ruleClasses) {
+        @SuppressWarnings("rawtypes")
+        Map<String, Class> mapRuleHandlers = mapRuleClasses(ruleClasses);
+        if (!mapRuleHandlers.isEmpty()) {
+            ruleHandlers.clear();
+            ruleHandlers.putAll(mapRuleHandlers);
+        }
+    }
+
+    protected List<Class> listClassesInPackage(String packageName) {
+        try {
+            return ResourceHelper.findClassesInPackage(packageName);
         } catch (Exception e) {
             addErrorMessage("loadRuleMappings: " + e.getMessage());
+            return Collections.<Class> emptyList();
+        }
+    }
+
+    protected Map<String, Class> mapRuleClasses(Iterable<Class> classes) {
+        try {
+            Map<String, Class> mapRuleHandlers = new HashMap<String, Class>();
+            for (Class clazz : classes) {
+                ProcessRule a = (ProcessRule) clazz.getAnnotation(ProcessRule.class);
+                if (a != null) {
+                    for (String rule : a.rule()) {
+                        mapRuleHandlers.put(rule, clazz);
+                    }
+                }
+            }
+            return mapRuleHandlers;
+        } catch (Exception e) {
+            addErrorMessage("loadRuleMappings: " + e.getMessage());
+            return Collections.emptyMap();
         }
     }
     

--- a/src/main/java/com/creativewidgetworks/goldparser/parser/GOLDParserBuildContext.java
+++ b/src/main/java/com/creativewidgetworks/goldparser/parser/GOLDParserBuildContext.java
@@ -1,0 +1,71 @@
+package com.creativewidgetworks.goldparser.parser;
+
+import static com.creativewidgetworks.goldparser.util.FileHelper.toInputStream;
+import static com.creativewidgetworks.goldparser.util.FormatHelper.formatMessage;
+import static com.creativewidgetworks.goldparser.util.ResourceHelper.findClassesInPackage;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+public final class GOLDParserBuildContext {
+    private InputStream grammar;
+    @SuppressWarnings("rawtypes")
+    private List<Class> ruleClasses;
+    private boolean trimReductions = true;
+
+    public GOLDParserBuildContext() {
+    }
+
+    public static GOLDParserBuildContext newContext() {
+        return new GOLDParserBuildContext();
+    }
+
+    public GOLDParserBuildContext grammar(InputStream stream) {
+        this.grammar = stream;
+        return this;
+    }
+
+    public GOLDParserBuildContext grammar(File file) throws IOException {
+        return grammar(toInputStream(file));
+    }
+
+    @SuppressWarnings("rawtypes")
+    public GOLDParserBuildContext ruleClasses(List<Class> ruleClasses) {
+        if (ruleClasses.size() == 0) {
+            throw new IllegalStateException(formatMessage("messages", "error.handlers_none"));
+        }
+        this.ruleClasses = ruleClasses;
+        return this;
+    }
+
+    public GOLDParserBuildContext rulesPackage(String rulesPackage) throws ClassNotFoundException, IOException {
+        return ruleClasses(findClassesInPackage(rulesPackage));
+    }
+
+    public GOLDParserBuildContext trimReductions(boolean trimReductions) {
+        this.trimReductions = trimReductions;
+        return this;
+    }
+
+    /**
+     * @return the {@link InputStream} to use to read the grammar
+     */
+    public InputStream grammar() {
+        return grammar;
+    }
+
+    /**
+     * @return the list of {@link com.creativewidgetworks.goldparser.engine.Reduction} that are annotated with
+     *         {@link ProcessRule}
+     */
+    public List<Class> ruleClasses() {
+        return ruleClasses;
+    }
+
+    public boolean trimReductions() {
+        return trimReductions;
+    }
+
+}

--- a/src/main/java/com/creativewidgetworks/goldparser/util/FileHelper.java
+++ b/src/main/java/com/creativewidgetworks/goldparser/util/FileHelper.java
@@ -1,0 +1,16 @@
+package com.creativewidgetworks.goldparser.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class FileHelper {
+
+    public static FileInputStream toInputStream(File file) throws IOException {
+        if (file == null) {
+            throw new IOException(FormatHelper.formatMessage("messages", "error.cgt_missing"));
+        }
+        return new FileInputStream(file);
+    }
+
+}


### PR DESCRIPTION
The use of a context allows to delegate the loading of reduction
classes to the caller.

This allows loading chosen rules from a separate jar, or from different
packages.

Change-Id: I43be172f6c3f121100edcaee406d54bed1adeeb5