### PR TITLE
Bugfix proposal for #28

### DIFF
--- a/engine/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
+++ b/engine/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
@@ -696,11 +696,7 @@ public class Parser {
                 inputTokens.push(read);
                 
                 // Handle the case where an unterminated comment block consumes the entire program
-                // START KGU#1144 2024-04-10: Bugfix #28 With a line comment, we may tolerate EOF
-                //if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
-                if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0
-                        && !(groupStack.size() == 1 && groupStack.peek().group.getEndingMode() == EndingMode.OPEN)) {
-                // END KGU#1144 2024-04-10
+                if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
                     // Runaway group
                     parseMessage = ParseMessage.GROUP_ERROR;                    
                 } else {
@@ -719,11 +715,7 @@ public class Parser {
                 } else if (SymbolType.ERROR.equals(read.getType())) {
                     parseMessage = ParseMessage.LEXICAL_ERROR;
                     done = true;
-                // START KGU#1144 2024-04-10: Bugfix #28 With a line comment, we may tolerate EOF
-                //} else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
-                } else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0
-                        && !(groupStack.size() == 1 && groupStack.peek().group.getEndingMode() == EndingMode.OPEN)) {
-                // END KGU #1144 2024-04-10
+                } else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
                     // Runaway group
                     parseMessage = ParseMessage.GROUP_ERROR;
                     done = true;                    
@@ -946,7 +938,21 @@ public class Parser {
                 }
             } else if (read.getType().equals(SymbolType.END)) {
                 // EOF always stops the loop. The caller method (parse) can flag a runaway group error.
-                token = read;
+                // START KGU#1144 2024-04-15: Bugfix #28 Save a line comment at end of file
+                //token = read;
+                // An open group (e.g. line comment) expecting just some NOISE, however, should be preserved
+                Token grp = null;
+                if (groupStack.size() == 1
+                        && (grp = groupStack.peek()).getGroup().getEndingMode() == EndingMode.OPEN
+                        && grp.getGroup().getEnd().getType().equals(SymbolType.NOISE)) {
+                    groupStack.pop();
+                    grp.setSymbol(grp.getGroup().getContainer());
+                    token = grp;
+                }
+                else {
+                    token = read;
+                }
+                // END KGU#1144 2024-04-15
                 done = true;
             } else {
                 // We are in a group, Append to the Token on the top of the stack.

--- a/engine/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
+++ b/engine/src/main/java/com/creativewidgetworks/goldparser/engine/Parser.java
@@ -696,7 +696,11 @@ public class Parser {
                 inputTokens.push(read);
                 
                 // Handle the case where an unterminated comment block consumes the entire program
-                if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
+                // START KGU#1144 2024-04-10: Bugfix #28 With a line comment, we may tolerate EOF
+                //if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
+                if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0
+                        && !(groupStack.size() == 1 && groupStack.peek().group.getEndingMode() == EndingMode.OPEN)) {
+                // END KGU#1144 2024-04-10
                     // Runaway group
                     parseMessage = ParseMessage.GROUP_ERROR;                    
                 } else {
@@ -715,7 +719,11 @@ public class Parser {
                 } else if (SymbolType.ERROR.equals(read.getType())) {
                     parseMessage = ParseMessage.LEXICAL_ERROR;
                     done = true;
-                } else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
+                // START KGU#1144 2024-04-10: Bugfix #28 With a line comment, we may tolerate EOF
+                //} else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0) {
+                } else if (SymbolType.END.equals(read.getType()) && groupStack.size() > 0
+                        && !(groupStack.size() == 1 && groupStack.peek().group.getEndingMode() == EndingMode.OPEN)) {
+                // END KGU #1144 2024-04-10
                     // Runaway group
                     parseMessage = ParseMessage.GROUP_ERROR;
                     done = true;                    


### PR DESCRIPTION
Parsing used to fail with error.group_runaway if the parsed file ends with a line comment group since the newlines before the EOF are suppressed by lookahadDFA(). Therefor, this hack tolerates a single group with endingMode OPEN on the group stack when an EOF token is ahead.